### PR TITLE
Fix - Add status on project && Delete referenced project

### DIFF
--- a/src/database/migrations/20230307201538-create-project.js
+++ b/src/database/migrations/20230307201538-create-project.js
@@ -31,6 +31,10 @@ module.exports = {
       endDate: {
         type: Sequelize.DATE,
       },
+      status: {
+        type: Sequelize.ENUM("pending", "in-progress", "completed"),
+        defaultValue: "pending",
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/src/database/models/project.js
+++ b/src/database/models/project.js
@@ -37,6 +37,10 @@ const ProjectModel = () => {
       endDate: {
         type: DataTypes.DATE,
       },
+      status: {
+        type: DataTypes.ENUM("pending", "in-progress", "completed"),
+        defaultValue: "pending",
+      },
     },
     {
       sequelize,

--- a/src/database/relationships/index.js
+++ b/src/database/relationships/index.js
@@ -15,17 +15,25 @@ export const associate = () => {
   });
 
   DB.Project.hasMany(DB.UserProject, {
+    as: "userProjects",
     onDelete: "CASCADE",
     foreignKey: "projectId",
   });
-  DB.UserProject.belongsTo(DB.Project, { foreignKey: "projectId" });
+  DB.UserProject.belongsTo(DB.Project, {
+    as: "project",
+    foreignKey: "projectId",
+  });
 
   DB.User.hasMany(DB.UserProject, {
+    as: "userProjects",
     onDelete: "CASCADE",
     foreignKey: "userId",
   });
 
-  DB.UserProject.belongsTo(DB.User, { foreignKey: "userId" });
+  DB.UserProject.belongsTo(DB.User, {
+    as: "developer",
+    foreignKey: "userId",
+  });
 
   DB.User.hasMany(DB.Review, {
     foreignKey: "reviewerId",

--- a/src/documentation/projects/index.js
+++ b/src/documentation/projects/index.js
@@ -222,6 +222,69 @@ const projects = {
       responses,
     },
   },
+
+  patch: {
+    tags: ["Projects"],
+    summary: "Update a project",
+    description: "Update a project. Only admin users can update a project.",
+    security: [{ JWT: [] }],
+    parameters: [
+      {
+        in: "path",
+        name: "projectId",
+        required: true,
+        schema: {
+          example: "8a2a4287-fd47-45f9-a1a0-42e24aeeeddz",
+        },
+      },
+      {
+        in: "body",
+        name: "body",
+        required: true,
+        schema: {
+          example: {
+            name: "Project name",
+            description: "Project description",
+            startDate: "2023-03-09T13:33:43.076Z",
+            endDate: "2023-03-09T13:33:43.076Z",
+          },
+        },
+      },
+    ],
+    consumes: ["application/json"],
+    responses,
+  },
+
+  "/projects/{projectId}/status": {
+    patch: {
+      tags: ["Projects"],
+      summary: "Change project status",
+      description: "Change project status. Only the project lead can do that.",
+      security: [{ JWT: [] }],
+      parameters: [
+        {
+          in: "path",
+          name: "projectId",
+          required: true,
+          schema: {
+            example: "8a2a4287-fd47-45f9-a1a0-42e24aeeeddz",
+          },
+        },
+        {
+          in: "body",
+          name: "body",
+          required: true,
+          schema: {
+            example: {
+              status: "completed",
+            },
+          },
+        },
+      ],
+      consumes: ["application/json"],
+      responses,
+    },
+  },
 };
 
 export default projects;

--- a/src/restful/controllers/projectController.js
+++ b/src/restful/controllers/projectController.js
@@ -401,4 +401,40 @@ export default class projectController {
         .json({ message: "server error", error: error.message });
     }
   }
+
+  static async changeProjectStatus(req, res) {
+    const leadId = req.user?.id;
+    const { projectId } = req.params;
+    try {
+      const project = await findProjectById(projectId);
+      if (project && project.projectLeadId === leadId) {
+        const status = req.body.status;
+
+        const validStatus = ["pending", "in-progress", "completed"];
+        if (!validStatus.includes(status)) {
+          return res.status(400).json({ message: "Invalid status" });
+        }
+        await project.update({ status: status });
+        return res.status(200).json({
+          message: `Project status changed to ${status}`,
+        });
+      }
+
+      if (!project) {
+        return res.status(404).json({ error: "Project not found" });
+      }
+
+      if (project.projectLeadId !== leadId) {
+        return res.status(401).json({
+          message:
+            "Not Authorized! Only project lead can change project status",
+        });
+      }
+    } catch (error) {
+      console.error(error);
+      return res
+        .status(500)
+        .json({ message: "server error", error: error.message });
+    }
+  }
 }

--- a/src/restful/routes/projectRoutes.js
+++ b/src/restful/routes/projectRoutes.js
@@ -12,6 +12,7 @@ const {
   addUserToProject,
   removeUserFromProject,
   setProjectLead,
+  changeProjectStatus,
 } = projectController;
 
 const projectRouter = Router();
@@ -25,5 +26,6 @@ projectRouter.get("/:projectId/users", protect, getProjectUsers);
 projectRouter.put("/:projectId/users", protect, addUserToProject);
 projectRouter.delete("/:projectId/users", protect, removeUserFromProject);
 projectRouter.patch("/:projectId/lead", protect, setProjectLead);
+projectRouter.patch("/:projectId/status", protect, changeProjectStatus);
 
 export default projectRouter;


### PR DESCRIPTION
# What does this PR do?
- this PR fixes the issue of deleting referenced projects
- this PR adds a status field on the project
# Description of Task to be completed?
- Before deleting the project delete all userProject records that references it
- Add a status field in the project model and migration

## Requirements

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Require dependences installation
- [ ] Require .env update
- [ ] Documentation updated

# How should this be manually tested?
> - Clone this repository
> - checkout to this branch `fix-delete-project`
> - install the dependencies `npm install` and 
> - Run migrations `npm run db:migrate` 
> - Create some users or run seeds `npm run db:seed` and then start the server `npm run dev`
> - Go to `http://localhost:$PORT/api/v1/docs` in your browser to access the api documentation
# Any background context you want to provide?

# What are the relevant pivotal tracker stories?

# Screenshots (if appropriate)

# Questions:
- N/A